### PR TITLE
Catch FileNotFoundError due to undownloaded Kobo ebooks

### DIFF
--- a/Obok_plugin/action.py
+++ b/Obok_plugin/action.py
@@ -374,7 +374,11 @@ class InterfacePluginAction(InterfaceAction):
         result['success'] = False
         result['fileobj'] = None
 
-        zin = zipfile.ZipFile(book.filename, 'r')
+        try:
+            zin = zipfile.ZipFile(book.filename, 'r')
+        except FileNotFoundError:
+            print(_("File not found. Make sure that the ebook has been properly downloaded in the Kobo app. ("), book.filename, _(")"))
+            return result
         #print ('Kobo library filename: {0}'.format(book.filename))
         for userkey in self.userkeys:
             print (_('Trying key: '), codecs.encode(userkey, 'hex'))


### PR DESCRIPTION
If there exists at least one Kobo ebook that is in the library but not yet downloaded and the user tries to deDRM the whole Kobo folder, the entire process fails due to an uncaught `FileNotFoundError` in Obok_plugin/action.py, in the `decryptBook` function.

This patch catches the error, properly returns the error code and lets the process continue with the rest of the books without freezing the whole app.

I guess the error reporting could be made more user-friendly but not quite sure what's the best approach for that.